### PR TITLE
Update example scripts

### DIFF
--- a/contrib/scripts/ceylon-example
+++ b/contrib/scripts/ceylon-example
@@ -10,8 +10,9 @@
 
 USAGE='<arg1> <arg2>'
 DESCRIPTION='Example command that does nothing'
-LONG_USAGE='This script just shows how to create
-custom "ceylon" sub-commands.'
+LONG_USAGE='This script just shows how to create custom "ceylon" sub-commands.
+
+This long usage information is printed when users run `ceylon help example` or `ceylon example --help`. The plugin system already wraps long lines, so you should avoid wrapping them yourself.'
 
 . $CEYLON_HOME/bin/ceylon-sh-setup
 

--- a/contrib/scripts/ceylon-example.bat
+++ b/contrib/scripts/ceylon-example.bat
@@ -11,8 +11,21 @@ rem list of existing commands (try typing "ceylon help").
 
 set "USAGE=<arg1> <arg2>"
 set "DESCRIPTION=Example command that does nothing"
-set "LONG_USAGE=This script just shows how to create"
-set "LONG_USAGE=%LONG_USAGE% custom 'ceylon' sub-commands."
+
+rem Batch syntax:
+rem Caret (^) + single line break = no line break in resulting variable.
+rem  (Useful to line-wrap your script itself without affecting the result.)
+rem  (Don't forget to include spaces.)
+rem Caret (^) + double line break = one line break in resulting variable.
+rem  (Repeat to introduce a blank line in the result, i.e. a new paragraph.)
+set LONG_USAGE=This script just shows how to create custom 'ceylon' sub-commands.^
+
+^
+
+This long usage information is printed ^
+when users run `ceylon help example` or `ceylon example --help`. ^
+The plugin system already wraps long lines, ^
+so you should avoid wrapping them yourself.
 
 call %CEYLON_HOME%\bin\ceylon-sh-setup.bat %*
 


### PR DESCRIPTION
1. The scripts should not line-wrap the text manually.
2. Demonstrate batch syntax to put line breaks into a variable.

Result of two long discussions on ceylon/ceylon.formatter@7a100d4 and ceylon/ceylon.formatter@ce28b1a with @quintesse and @sgalles.
